### PR TITLE
feat: changed requestsThreshold default value to 1

### DIFF
--- a/src/default.ts
+++ b/src/default.ts
@@ -4,7 +4,7 @@ import { CacheCandidateOptions } from './models';
 export const CacheCandidateOptionsDefault: CacheCandidateOptions = {
   ttl: 600000,
   timeFrame: 30000,
-  requestsThreshold: 3,
+  requestsThreshold: 1,
   cache: makeAsyncMap(),
   keepAlive: false,
   plugins: [],


### PR DESCRIPTION
@rollsappletree as discussed I was thinking about going with a default of "1" for the requestsThreshold so that, if no options are passed, the candidate will cache the function when firstly encountered.