### PR TITLE
feat: expiration mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ The options available are:
   - `timeFrameCacheRecords`: The cache records of the last `timeFrame` milliseconds.
 - `millisecondThreshold` (_optional_): The threshold in milliseconds to be considered for the condition checks. If not passed, this criteria will be ignored.
 - `requestsThreshold` (_optional_): The number of requests to be considered for the condition checks. Default: `3`.
+- `expirationMode` (_optional_): The expiration mode to use. Default: `default`.
+    - `default`: The cache-candidate will be responsible for generating timeouts that, when reached, will call the provided delete method of the cache adapter.  
+    - `timeout-only`: The cache-candidate will be responsible for generating timeouts that, when reached, will *not* call the provided delete method of the cache adapter. This means your cache adapter must have a mechanism to delete the cache record when the timeout is reached (Ex. Redis EX option). Plugins and events will be called as usual.  
+    - `eject`: The cache-candidate will not be responsible for generating timeouts nor calling the delete method. This means your cache adapter must have a mechanism to delete the cache record when the timeout is reached (Ex. Redis EX option). *Be aware plugins and events will not be called.*
+
 - `keepAlive` (_optional_): If `true`, the cache record will be kept alive at every request. Default: `false`.
 - `cache` (_optional_): The cache adapter to be used. Defaults to `an in-memory cache based on Maps, but with Promises`.  
   Available adapters are:

--- a/src/default.ts
+++ b/src/default.ts
@@ -6,6 +6,7 @@ export const CacheCandidateOptionsDefault: CacheCandidateOptions = {
   timeFrame: 30000,
   requestsThreshold: 3,
   cache: makeAsyncMap(),
+  expirationMode: 'default',
   keepAlive: false,
   plugins: [],
   fetchingMode: 'default',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -257,6 +257,24 @@ describe('Library-wide Conditions', () => {
     expect(eventHits.get('onCacheDelete')).toBe(0);
   });
 
+  it("should call onCacheDelete when expirationMode is 'timeout-only' and ttl has passed", async () => {
+    const mockFn = jest.fn();
+    const wrappedMockFn = cacheCandidate(mockFn, {
+      expirationMode: 'timeout-only',
+      requestsThreshold: 1,
+      timeFrame: TTL * 2,
+      ttl: TTL,
+      events: {
+        onCacheDelete: () => {
+          eventHits.set('onCacheDelete', eventHits.get('onCacheDelete')! + 1);
+        }
+      }
+    });
+    wrappedMockFn(1);
+    await sleep(TTL + EXECUTION_MARGIN);
+    expect(eventHits.get('onCacheDelete')).toBe(1);
+  });
+
   it('should empty the timeframe cache after timeframe has passed', async () => {
     let counter = 0;
     const mockFn = (step: number) =>

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -24,6 +24,15 @@ beforeEach(async () => {
 });
 
 describe('Basic Test Environment', () => {
+  it('should throw if expirationMode is \'eject\' and \'keepAlive\' is true', async () => {
+    expect(() => {
+      cacheCandidate(() => {return Promise.resolve(true);}, {
+        expirationMode: 'eject',
+        keepAlive: true
+      });
+    }).toThrow();
+  });
+
   it('should verify cache is empty', async () => {
     expect(eventHits.get('onCacheSet')).toBe(0);
     expect(eventHits.get('onCacheHit')).toBe(0);

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -7,7 +7,8 @@ import {
   addDataCacheRecord,
   deleteDataCacheRecord,
   isDataCacheRecordExpired,
-  getExceedingAmount
+  getExceedingAmount,
+  checkExpirationMode
 } from './internal';
 
 import { CacheCandidateInputOptions } from './models';
@@ -24,6 +25,7 @@ export function CacheCandidate(_options: CacheCandidateInputOptions = {}) {
   } = getInitialState(_options);
 
   checkHooks({ options });
+  checkExpirationMode(options);
 
   ExecuteHook(Hooks.SETUP, options.plugins, {
     options: { ...options, plugins: undefined },
@@ -87,6 +89,7 @@ export function cacheCandidate<T extends (...args: any[]) => Promise<any>>(
   } = getInitialState(_options);
 
   checkHooks({ options });
+  checkExpirationMode(options);
 
   ExecuteHook(Hooks.SETUP, options.plugins, {
     options: { ...options, plugins: undefined },

--- a/src/models.ts
+++ b/src/models.ts
@@ -44,6 +44,7 @@ export interface CacheCandidateOptions {
   candidateFunction?: (CandidateFunctionOptions) => boolean;
   millisecondThreshold?: number;
   requestsThreshold: number;
+  expirationMode: 'default' | 'timeout-only' | 'eject';
   keepAlive: boolean;
   cache: CacheCandidateCacheAdapter;
   fetchingMode: 'stale-while-revalidate' | 'default';

--- a/src/models.ts
+++ b/src/models.ts
@@ -19,6 +19,7 @@ export interface CacheCandidateInputOptions {
   candidateFunction?: (CandidateFunctionOptions) => boolean;
   millisecondThreshold?: number;
   requestsThreshold?: number;
+  expirationMode?: 'default' | 'timeout-only' | 'eject';
   keepAlive?: boolean;
   cache?: CacheCandidateCacheAdapter;
   fetchingMode?: 'stale-while-revalidate' | 'default';


### PR DESCRIPTION
This PR adds expirationMode functionality.
This allows devs using the library to define how to manage expiration times and timeout bombs for their cache-candidate configuration.

The draft status is because one thing is missing:
Try to understand how to make it possible to use the `eject` mode but still passing meaningful information to the cache-candidate to properly call hooks and events. As of right now, the closer we can get is by using the `timeout-only` mode.