### PR TITLE
fix: events had to be passed entirely as options when present

### DIFF
--- a/src/internal.ts
+++ b/src/internal.ts
@@ -416,7 +416,11 @@ export function getInitialState(_options: Partial<CacheCandidateOptions>) {
 
   const options: CacheCandidateOptions = {
     ...CacheCandidateOptionsDefault,
-    ..._options
+    ..._options,
+    events: {
+      ...CacheCandidateOptionsDefault.events,
+      ...(_options.events || {})
+    }
   };
 
   return {


### PR DESCRIPTION
Before this PR, when you had to use a single event, you were forced to also declare all the others.
By adjusting the "getInitialState" function the problem was fixed.