### PR TITLE
fix: emitting onCacheHit for runningQuery match

### DIFF
--- a/src/internal.ts
+++ b/src/internal.ts
@@ -360,6 +360,7 @@ export async function letsCandidate({
       ...HookPayload,
       result: runningQuery
     });
+    options.events.onCacheHit({ key });
     return runningQuery;
   }
 


### PR DESCRIPTION
I found out events `onCacheHit` isn't being called for running queries cache hit.